### PR TITLE
Set up testing and build environment

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,13 +6,17 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
+echo "========================================="
 echo "Setting up tRNAs-in-space environment..."
+echo "========================================="
+echo ""
 
 # Install Python dependencies
 if [ -f "$CLAUDE_PROJECT_DIR/requirements.txt" ]; then
-  echo "Installing Python dependencies from requirements.txt..."
+  echo "📦 Installing Python dependencies from requirements.txt..."
   pip install -q -r "$CLAUDE_PROJECT_DIR/requirements.txt"
   echo "✓ Dependencies installed successfully"
+  echo ""
 fi
 
 # Set PYTHONPATH to include scripts directory
@@ -20,4 +24,27 @@ if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
   echo 'export PYTHONPATH="$CLAUDE_PROJECT_DIR:$CLAUDE_PROJECT_DIR/scripts"' >> "$CLAUDE_ENV_FILE"
 fi
 
-echo "✓ Environment setup complete"
+# Verify Python version
+echo "🐍 Python version:"
+python --version
+echo ""
+
+# Quick syntax check
+echo "🔍 Running quick syntax validation..."
+python -m py_compile scripts/trnas_in_space.py 2>/dev/null && echo "  ✓ scripts/trnas_in_space.py syntax OK" || echo "  ⚠ scripts/trnas_in_space.py has syntax errors"
+python -m py_compile test_trnas_in_space.py 2>/dev/null && echo "  ✓ test_trnas_in_space.py syntax OK" || echo "  ⚠ test_trnas_in_space.py has syntax errors"
+echo ""
+
+# Display available commands
+echo "📋 Available commands:"
+echo "  make test      - Run all tests"
+echo "  make lint      - Check code quality"
+echo "  make format    - Auto-format code"
+echo "  make build     - Run full build"
+echo "  make all       - Format, lint, test, and build"
+echo "  ./build.sh     - Run build script directly"
+echo ""
+
+echo "========================================="
+echo "✓ Environment setup complete!"
+echo "========================================="

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,16 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503, E501
+exclude =
+    .git,
+    __pycache__,
+    .pytest_cache,
+    .mypy_cache,
+    .venv,
+    venv,
+    build,
+    dist,
+    *.egg-info
+max-complexity = 10
+count = True
+statistics = True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,121 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master, develop ]
+  pull_request:
+    branches: [ main, master, develop ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run tests
+      run: |
+        python test_trnas_in_space.py
+
+    - name: Run tests with pytest
+      run: |
+        pytest test_trnas_in_space.py -v --tb=short
+
+    - name: Run tests with coverage
+      run: |
+        pytest test_trnas_in_space.py --cov=scripts --cov-report=term --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      if: matrix.python-version == '3.11'
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
+
+  lint:
+    name: Code Quality
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Check code formatting with Black
+      run: |
+        black --check --diff scripts/ test_trnas_in_space.py
+
+    - name: Check import sorting with isort
+      run: |
+        isort --check-only --diff scripts/ test_trnas_in_space.py
+
+    - name: Lint with flake8
+      run: |
+        # Stop the build if there are Python syntax errors or undefined names
+        flake8 scripts/ test_trnas_in_space.py --count --select=E9,F63,F7,F82 --show-source --statistics
+        # Exit-zero treats all errors as warnings
+        flake8 scripts/ test_trnas_in_space.py --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
+
+    - name: Type check with mypy
+      run: |
+        mypy scripts/ test_trnas_in_space.py --ignore-missing-imports || true
+
+  build:
+    name: Build and Validate
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run build script
+      run: |
+        chmod +x build.sh
+        ./build.sh
+
+    - name: Validate syntax
+      run: |
+        python -m py_compile scripts/trnas_in_space.py
+        python -m py_compile test_trnas_in_space.py
+
+    - name: Check for output files
+      run: |
+        ls -lh outputs/

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,43 @@ work/
 # Ignore editor/OS cruft
 .DS_Store
 *.swp
+*.swo
+*~
+.vscode/
+.idea/
 
 # Ignore Python cache
 __pycache__/
 *.pyc
 *.pyo
+*.pyd
+
+# Testing and coverage
+.pytest_cache/
+.coverage
+coverage.xml
+htmlcov/
+.tox/
+.nox/
+
+# Type checking
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+*.egg
+.eggs/
+
+# Virtual environments
+venv/
+.venv/
+env/
+ENV/
+
+# Pre-commit
+.pre-commit-config.yaml.bak
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,47 @@
+# Pre-commit hooks for code quality
+# Install: pip install pre-commit
+# Setup: pre-commit install
+# Run manually: pre-commit run --all-files
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: debug-statements
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        language_version: python3
+        args: ['--line-length=100']
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ['--profile=black', '--line-length=100']
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        args: ['--max-line-length=100', '--extend-ignore=E203,W503']
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-all]
+        args: ['--ignore-missing-imports', '--no-strict-optional']
+        exclude: ^test_.*\.py$

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,92 @@
+.PHONY: help install test lint format clean build check all
+
+# Default target
+help:
+	@echo "tRNAs-in-space Development Tasks"
+	@echo "================================="
+	@echo ""
+	@echo "Available targets:"
+	@echo "  make install    - Install all dependencies"
+	@echo "  make test       - Run all tests"
+	@echo "  make lint       - Run all linters"
+	@echo "  make format     - Format code with black and isort"
+	@echo "  make check      - Run linters without making changes"
+	@echo "  make build      - Run the build script"
+	@echo "  make clean      - Remove generated files"
+	@echo "  make all        - Run format, lint, test, and build"
+	@echo ""
+
+# Install dependencies
+install:
+	@echo "Installing dependencies..."
+	pip install -r requirements.txt
+	@echo "✓ Dependencies installed"
+
+# Run tests
+test:
+	@echo "Running tests..."
+	@python test_trnas_in_space.py
+	@echo ""
+	@echo "Running tests with pytest..."
+	@pytest test_trnas_in_space.py -v
+	@echo "✓ All tests passed"
+
+# Run tests with coverage
+test-cov:
+	@echo "Running tests with coverage..."
+	@pytest test_trnas_in_space.py --cov=scripts --cov-report=term --cov-report=html
+	@echo "✓ Coverage report generated in htmlcov/"
+
+# Format code
+format:
+	@echo "Formatting code with black..."
+	@black scripts/ test_trnas_in_space.py
+	@echo "Sorting imports with isort..."
+	@isort scripts/ test_trnas_in_space.py
+	@echo "✓ Code formatted"
+
+# Check code style without changes
+check:
+	@echo "Checking code formatting..."
+	@black --check --diff scripts/ test_trnas_in_space.py || true
+	@echo ""
+	@echo "Checking import order..."
+	@isort --check-only --diff scripts/ test_trnas_in_space.py || true
+	@echo ""
+	@echo "Running flake8..."
+	@flake8 scripts/ test_trnas_in_space.py --max-line-length=100 --statistics || true
+	@echo ""
+	@echo "Running mypy..."
+	@mypy scripts/ test_trnas_in_space.py --ignore-missing-imports || true
+
+# Lint code
+lint:
+	@echo "Running flake8..."
+	@flake8 scripts/ test_trnas_in_space.py --count --select=E9,F63,F7,F82 --show-source --statistics
+	@flake8 scripts/ test_trnas_in_space.py --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
+	@echo ""
+	@echo "Type checking with mypy..."
+	@mypy scripts/ test_trnas_in_space.py --ignore-missing-imports || true
+	@echo "✓ Linting complete"
+
+# Build and validate
+build:
+	@echo "Running build script..."
+	@chmod +x build.sh
+	@./build.sh
+	@echo "✓ Build complete"
+
+# Clean generated files
+clean:
+	@echo "Cleaning generated files..."
+	@rm -rf __pycache__ scripts/__pycache__ .pytest_cache .mypy_cache .coverage htmlcov/ *.pyc
+	@find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	@find . -type f -name "*.pyc" -delete
+	@echo "✓ Clean complete"
+
+# Run everything
+all: format lint test build
+	@echo ""
+	@echo "========================================"
+	@echo "✓ All tasks completed successfully!"
+	@echo "========================================"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,126 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "trnas-in-space"
+version = "1.0.0"
+description = "tRNA coordinate mapping from R2DT Sprinzl labels to global index"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "pandas>=2.0.0",
+    "numpy>=1.24.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-cov>=4.1.0",
+    "pytest-xdist>=3.3.0",
+    "black>=23.0.0",
+    "flake8>=6.0.0",
+    "pylint>=2.17.0",
+    "mypy>=1.4.0",
+    "isort>=5.12.0",
+    "pandas-stubs>=2.0.0",
+    "types-setuptools>=68.0.0",
+]
+
+[tool.black]
+line-length = 100
+target-version = ['py38', 'py39', 'py310', 'py311']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 100
+skip_gitignore = true
+known_first_party = ["trnas_in_space"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = [
+    "-ra",
+    "--strict-markers",
+    "--strict-config",
+    "--showlocals",
+    "--tb=short",
+]
+testpaths = [".", "scripts"]
+python_files = ["test_*.py", "*_test.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+
+[tool.coverage.run]
+source = ["scripts"]
+branch = true
+omit = [
+    "*/tests/*",
+    "*/test_*.py",
+    "*/__pycache__/*",
+]
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "@abstractmethod",
+]
+
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+follow_imports = "normal"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pandas.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "numpy.*"
+ignore_missing_imports = true
+
+[tool.pylint.messages_control]
+max-line-length = 100
+disable = [
+    "C0103",  # Invalid name
+    "C0114",  # Missing module docstring
+    "C0115",  # Missing class docstring
+    "C0116",  # Missing function docstring
+    "R0913",  # Too many arguments
+    "R0914",  # Too many local variables
+    "W0212",  # Access to protected member
+]
+
+[tool.pylint.format]
+max-line-length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,19 @@
+# Core dependencies
 pandas>=2.0.0
 numpy>=1.24.0
+
+# Testing
+pytest>=7.4.0
+pytest-cov>=4.1.0
+pytest-xdist>=3.3.0
+
+# Linting and formatting
+black>=23.0.0
+flake8>=6.0.0
+pylint>=2.17.0
+mypy>=1.4.0
+isort>=5.12.0
+
+# Type stubs
+pandas-stubs>=2.0.0
+types-setuptools>=68.0.0

--- a/scripts/trnas_in_space.py
+++ b/scripts/trnas_in_space.py
@@ -24,6 +24,7 @@ PRECISION = 6  # fixed rounding for sprinzl_continuous before uniquing
 
 # ------------------------- helpers: files -------------------------
 
+
 def infer_trna_id_from_filename(path: str) -> str:
     base = os.path.basename(path)
     name = base
@@ -34,7 +35,9 @@ def infer_trna_id_from_filename(path: str) -> str:
     m = re.match(r"^(.*?)-[A-Z]_[A-Za-z0-9]+$", name)  # strip "-B_His" style suffixes if present
     return m.group(1) if m else name
 
+
 # --------------------- phase 1: JSON -> rows ----------------------
+
 
 def collect_rows_from_json(fp: str):
     with open(fp, "r") as f:
@@ -53,14 +56,16 @@ def collect_rows_from_json(fp: str):
         sprinzl_idx = info.get("templateResidueIndex", None)
         sprinzl_idx = int(sprinzl_idx) if isinstance(sprinzl_idx, int) else -1
         sprinzl_lbl = (info.get("templateNumberingLabel", "") or "").strip()
-        rows.append({
-            "trna_id": trna_id,
-            "source_file": os.path.basename(fp),
-            "seq_index": ridx,
-            "sprinzl_index": sprinzl_idx,
-            "sprinzl_label": sprinzl_lbl,
-            "residue": rname,
-        })
+        rows.append(
+            {
+                "trna_id": trna_id,
+                "source_file": os.path.basename(fp),
+                "seq_index": ridx,
+                "sprinzl_index": sprinzl_idx,
+                "sprinzl_label": sprinzl_lbl,
+                "residue": rname,
+            }
+        )
 
     # Fill missing sprinzl_index by monotone inference along seq_index
     rows.sort(key=lambda r: r["seq_index"])
@@ -68,24 +73,28 @@ def collect_rows_from_json(fp: str):
     vals = [r["sprinzl_index"] for r in rows]
 
     # forward pass
-    fwd = [None]*n
+    fwd = [None] * n
     last = None
     for i in range(n):
         v = vals[i]
         if isinstance(v, int) and v >= 1:
-            fwd[i] = v; last = v
+            fwd[i] = v
+            last = v
         elif last is not None:
-            fwd[i] = last + 1; last += 1
+            fwd[i] = last + 1
+            last += 1
 
     # backward pass
-    bwd = [None]*n
+    bwd = [None] * n
     nxt = None
-    for i in range(n-1, -1, -1):
+    for i in range(n - 1, -1, -1):
         v = vals[i]
         if isinstance(v, int) and v >= 1:
-            bwd[i] = v; nxt = v
+            bwd[i] = v
+            nxt = v
         elif nxt is not None:
-            bwd[i] = nxt - 1; nxt -= 1
+            bwd[i] = nxt - 1
+            nxt -= 1
 
     for i, r in enumerate(rows):
         v = vals[i]
@@ -102,7 +111,9 @@ def collect_rows_from_json(fp: str):
 
     return rows
 
+
 # --------------- phase 2: label order & continuous ----------------
+
 
 def sort_key(lbl: str):
     """Order labels: 20 < 20A < 20B; allow dotted like 9.1; unknowns at end."""
@@ -111,12 +122,14 @@ def sort_key(lbl: str):
     s = str(lbl)
     m = re.fullmatch(r"(\d+)([A-Za-z]+)?", s)
     if m:
-        base = int(m.group(1)); suf = (m.group(2) or "").upper()
+        base = int(m.group(1))
+        suf = (m.group(2) or "").upper()
         return (base, 1 if suf else 0, suf)
     m = re.fullmatch(r"(\d+)\.(\d+)", s)
     if m:
         return (int(m.group(1)), 1, int(m.group(2)))
     return (10**9 - 1, 2, s)
+
 
 def build_pref_label(df: pd.DataFrame) -> pd.Series:
     """
@@ -130,10 +143,12 @@ def build_pref_label(df: pd.DataFrame) -> pd.Series:
     pref = lbl.mask(lbl.eq(""), other=num_ok_str)
     return pref
 
+
 def build_global_label_order(pref: pd.Series):
     uniq = sorted({p for p in pref if p not in ("", "nan")}, key=sort_key)
     to_ord = {u: i + 1 for i, u in enumerate(uniq)}  # 1..K
     return uniq, to_ord
+
 
 def make_continuous_for_trna(sub: pd.DataFrame, ord_series: pd.Series) -> pd.Series:
     """
@@ -156,24 +171,26 @@ def make_continuous_for_trna(sub: pd.DataFrame, ord_series: pd.Series) -> pd.Ser
         while j < n and pd.isna(ords[j]):
             j += 1
         k = j - i
-        left = int(ords[i-1]) if i-1 >= 0 and not pd.isna(ords[i-1]) else None
-        right = int(ords[j])   if j   <  n and not pd.isna(ords[j])   else None
+        left = int(ords[i - 1]) if i - 1 >= 0 and not pd.isna(ords[i - 1]) else None
+        right = int(ords[j]) if j < n and not pd.isna(ords[j]) else None
         if left is not None and right is not None and right >= left + 1:
             for t in range(k):
-                vals[i+t] = left + (t+1)/(k+1)
+                vals[i + t] = left + (t + 1) / (k + 1)
         elif left is None and right is not None:
             for t in range(k):
-                vals[i+t] = right - (k - t)/(k+1)
+                vals[i + t] = right - (k - t) / (k + 1)
         elif left is not None and right is None:
             for t in range(k):
-                vals[i+t] = left + (t+1)/(k+1)
+                vals[i + t] = left + (t + 1) / (k + 1)
         else:
             for t in range(k):
-                vals[i+t] = np.nan
+                vals[i + t] = np.nan
         i = j
     return pd.Series(vals, index=sub.index, dtype="float64")
 
+
 # ------------------------ phase 3: regions -------------------------
+
 
 def sprinzl_numeric_from_label(label: str):
     """Extract leading integer from Sprinzl label like '20a', '14:i1' -> 20, 14."""
@@ -181,6 +198,7 @@ def sprinzl_numeric_from_label(label: str):
         return None
     m = re.match(r"(\d+)", str(label))
     return int(m.group(1)) if m else None
+
 
 def assign_region_from_sprinzl(base_num: int) -> str:
     """
@@ -191,17 +209,28 @@ def assign_region_from_sprinzl(base_num: int) -> str:
     if base_num is None:
         return "unknown"
     p = base_num
-    if (1 <= p <= 7) or (66 <= p <= 72): return "acceptor-stem"
-    if p == 73 or p > 73: return "acceptor-tail"  # include CCA if present
-    if (10 <= p <= 13) or (22 <= p <= 25): return "D-stem"
-    if 14 <= p <= 21: return "D-loop"
-    if (27 <= p <= 31) or (39 <= p <= 43): return "anticodon-stem"
-    if 32 <= p <= 38: return "anticodon-loop"
-    if 44 <= p <= 46: return "variable-region"
-    if 46 < p < 49: return "variable-arm"         # Type II long arm insertions
-    if (49 <= p <= 53) or (61 <= p <= 65): return "T-stem"
-    if 54 <= p <= 60: return "T-loop"
+    if (1 <= p <= 7) or (66 <= p <= 72):
+        return "acceptor-stem"
+    if p == 73 or p > 73:
+        return "acceptor-tail"  # include CCA if present
+    if (10 <= p <= 13) or (22 <= p <= 25):
+        return "D-stem"
+    if 14 <= p <= 21:
+        return "D-loop"
+    if (27 <= p <= 31) or (39 <= p <= 43):
+        return "anticodon-stem"
+    if 32 <= p <= 38:
+        return "anticodon-loop"
+    if 44 <= p <= 46:
+        return "variable-region"
+    if 46 < p < 49:
+        return "variable-arm"  # Type II long arm insertions
+    if (49 <= p <= 53) or (61 <= p <= 65):
+        return "T-stem"
+    if 54 <= p <= 60:
+        return "T-loop"
     return "unknown"
+
 
 def compute_region_column(df: pd.DataFrame) -> pd.Series:
     # prefer label’s numeric part; fall back to sprinzl_index (1..76)
@@ -212,11 +241,17 @@ def compute_region_column(df: pd.DataFrame) -> pd.Series:
     base_num = base_from_label.fillna(idx_fallback)
     return base_num.apply(assign_region_from_sprinzl)
 
+
 # -------------------------------- main ---------------------------------
 
+
 def main():
-    ap = argparse.ArgumentParser(description="Build global equal-spaced tRNA coordinates + regions from R2DT JSON.")
-    ap.add_argument("json_dir", help="Directory with R2DT *.enriched.json files (searched recursively).")
+    ap = argparse.ArgumentParser(
+        description="Build global equal-spaced tRNA coordinates + regions from R2DT JSON."
+    )
+    ap.add_argument(
+        "json_dir", help="Directory with R2DT *.enriched.json files (searched recursively)."
+    )
     ap.add_argument("out_tsv", help="Output TSV path.")
     args = ap.parse_args()
 
@@ -252,15 +287,25 @@ def main():
     # Global equal-spaced index (rounded internally to PRECISION)
     cont_round = df["sprinzl_continuous"].round(PRECISION)
     uniq_cont = sorted(cont_round.dropna().unique().tolist())
-    cont_to_global = {v: i+1 for i, v in enumerate(uniq_cont)}
+    cont_to_global = {v: i + 1 for i, v in enumerate(uniq_cont)}
     df["global_index"] = cont_round.map(cont_to_global).astype("Int64")
 
     # Region annotation from Sprinzl
     df["region"] = compute_region_column(df)
 
     # Write out
-    cols = ["trna_id","source_file","seq_index","sprinzl_index","sprinzl_label","residue",
-            "sprinzl_ordinal","sprinzl_continuous","global_index","region"]
+    cols = [
+        "trna_id",
+        "source_file",
+        "seq_index",
+        "sprinzl_index",
+        "sprinzl_label",
+        "residue",
+        "sprinzl_ordinal",
+        "sprinzl_continuous",
+        "global_index",
+        "region",
+    ]
     df.to_csv(args.out_tsv, sep="\t", index=False, columns=cols)
 
     # Stats
@@ -272,6 +317,7 @@ def main():
     missing = (df["sprinzl_index"] < 1).sum()
     if missing:
         print(f"  Note: {missing} rows still have sprinzl_index == -1 (unresolvable from JSON).")
+
 
 if __name__ == "__main__":
     main()

--- a/test_trnas_in_space.py
+++ b/test_trnas_in_space.py
@@ -13,7 +13,7 @@ import numpy as np
 from pathlib import Path
 
 # Add scripts directory to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'scripts'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "scripts"))
 
 import trnas_in_space
 
@@ -21,9 +21,9 @@ import trnas_in_space
 def test_imports():
     """Test that all required modules can be imported."""
     assert trnas_in_space is not None
-    assert hasattr(trnas_in_space, 'main')
-    assert hasattr(trnas_in_space, 'sort_key')
-    assert hasattr(trnas_in_space, 'assign_region_from_sprinzl')
+    assert hasattr(trnas_in_space, "main")
+    assert hasattr(trnas_in_space, "sort_key")
+    assert hasattr(trnas_in_space, "assign_region_from_sprinzl")
 
 
 def test_sort_key():
@@ -83,19 +83,19 @@ def test_assign_region_from_sprinzl():
 def test_infer_trna_id_from_filename():
     """Test tRNA ID inference from filenames."""
     # Standard enriched.json format
-    assert trnas_in_space.infer_trna_id_from_filename(
-        "tRNA-Ala-AGC-1-1-B_Ala.enriched.json"
-    ) == "tRNA-Ala-AGC-1-1"
+    assert (
+        trnas_in_space.infer_trna_id_from_filename("tRNA-Ala-AGC-1-1-B_Ala.enriched.json")
+        == "tRNA-Ala-AGC-1-1"
+    )
 
     # Simple format
-    assert trnas_in_space.infer_trna_id_from_filename(
-        "example.enriched.json"
-    ) == "example"
+    assert trnas_in_space.infer_trna_id_from_filename("example.enriched.json") == "example"
 
     # With path
-    assert trnas_in_space.infer_trna_id_from_filename(
-        "/path/to/tRNA-Leu-CAA-1-1-B_Leu.enriched.json"
-    ) == "tRNA-Leu-CAA-1-1"
+    assert (
+        trnas_in_space.infer_trna_id_from_filename("/path/to/tRNA-Leu-CAA-1-1-B_Leu.enriched.json")
+        == "tRNA-Leu-CAA-1-1"
+    )
 
 
 def test_output_files_exist():
@@ -106,7 +106,7 @@ def test_output_files_exist():
     expected_files = [
         "ecoliK12_global_coords.tsv",
         "sacCer_global_coords.tsv",
-        "hg38_global_coords.tsv"
+        "hg38_global_coords.tsv",
     ]
 
     for filename in expected_files:
@@ -127,9 +127,16 @@ def test_output_file_structure():
 
     # Check required columns
     expected_columns = [
-        "trna_id", "source_file", "seq_index", "sprinzl_index",
-        "sprinzl_label", "residue", "sprinzl_ordinal",
-        "sprinzl_continuous", "global_index", "region"
+        "trna_id",
+        "source_file",
+        "seq_index",
+        "sprinzl_index",
+        "sprinzl_label",
+        "residue",
+        "sprinzl_ordinal",
+        "sprinzl_continuous",
+        "global_index",
+        "region",
     ]
 
     for col in expected_columns:
@@ -143,9 +150,17 @@ def test_output_file_structure():
 
     # Check region values are valid
     valid_regions = [
-        "acceptor-stem", "acceptor-tail", "D-stem", "D-loop",
-        "anticodon-stem", "anticodon-loop", "variable-region",
-        "variable-arm", "T-stem", "T-loop", "unknown"
+        "acceptor-stem",
+        "acceptor-tail",
+        "D-stem",
+        "D-loop",
+        "anticodon-stem",
+        "anticodon-loop",
+        "variable-region",
+        "variable-arm",
+        "T-stem",
+        "T-loop",
+        "unknown",
     ]
     assert df["region"].isin(valid_regions).all(), "Invalid region values found"
 


### PR DESCRIPTION
This commit sets up a comprehensive development environment optimized for Claude Code and Claude Code web, including:

- Enhanced requirements.txt with testing tools (pytest, pytest-cov) and linting/formatting tools (black, flake8, pylint, mypy, isort)
- Added pyproject.toml for centralized project configuration including tool settings for black, isort, pytest, coverage, mypy, and pylint
- Created GitHub Actions CI/CD workflow (.github/workflows/ci.yml) with parallel jobs for testing, linting, and building across Python 3.8-3.11
- Added Makefile with convenient targets (test, lint, format, build, etc.) for common development tasks
- Added .pre-commit-config.yaml for automated code quality checks
- Enhanced .claude/hooks/session-start.sh with improved setup messaging, syntax validation, and helpful command display
- Created .flake8 configuration for consistent code style enforcement
- Updated .gitignore with comprehensive Python development exclusions

All changes tested and verified to work correctly.