### PR TITLE
Code quality fixes: resolve lint warnings and fix failing test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ isort>=5.12.0
 # Type stubs
 pandas-stubs>=2.0.0
 types-setuptools>=68.0.0
+types-PyYAML>=6.0.0

--- a/scripts/download_gtrnadb_fastas.py
+++ b/scripts/download_gtrnadb_fastas.py
@@ -141,7 +141,7 @@ def download_file(url, output_path, timeout=30):
 
             # Verify it's a FASTA file
             if not content.startswith(b'>'):
-                print(f"  ❌ Not a FASTA file (doesn't start with '>')")
+                print("  ❌ Not a FASTA file (doesn't start with '>')")
                 return False
 
             # Write to file
@@ -186,8 +186,10 @@ def download_organism_fasta(organism, manual_only=False):
     fastas_dir = PROJECT_ROOT / "fastas"
     fastas_dir.mkdir(exist_ok=True)
 
-    existing_files = list(fastas_dir.glob(f"*{organism_id}*.fa")) + \
-                     list(fastas_dir.glob(f"*{organism['gtrnadb_id']}*.fa"))
+    existing_files = (
+        list(fastas_dir.glob(f"*{organism_id}*.fa"))
+        + list(fastas_dir.glob(f"*{organism['gtrnadb_id']}*.fa"))
+    )
 
     if existing_files:
         print(f"✓ FASTA file already exists: {existing_files[0]}")
@@ -197,14 +199,14 @@ def download_organism_fasta(organism, manual_only=False):
     urls = construct_gtrnadb_url(organism)
 
     if manual_only:
-        print(f"\nManual download URLs to try:")
+        print("\nManual download URLs to try:")
         for url, filename in urls:
             print(f"  {url}")
         print(f"\nSave as: fastas/{organism['gtrnadb_id']}-tRNAs.fa")
         return {"success": False, "manual": True}
 
     # Try each URL
-    print(f"\nAttempting automated download...")
+    print("\nAttempting automated download...")
     for url, filename in urls:
         output_path = fastas_dir / f"{organism['gtrnadb_id']}-tRNAs.fa"
 
@@ -216,10 +218,10 @@ def download_organism_fasta(organism, manual_only=False):
 
     # All URLs failed
     print(f"\n❌ Automated download failed for {organism_name}")
-    print(f"\nPlease manually download from GtRNAdb:")
-    print(f"  1. Visit: http://gtrnadb.ucsc.edu/")
+    print("\nPlease manually download from GtRNAdb:")
+    print("  1. Visit: http://gtrnadb.ucsc.edu/")
     print(f"  2. Navigate to: {organism['kingdom']} → {organism_name}")
-    print(f"  3. Download mature tRNA sequences (FASTA)")
+    print("  3. Download mature tRNA sequences (FASTA)")
     print(f"  4. Save as: fastas/{organism['gtrnadb_id']}-tRNAs.fa")
 
     return {"success": False, "error": "All download URLs failed"}
@@ -262,7 +264,7 @@ def main():
         sys.exit(0)
 
     print(f"\n{'='*80}")
-    print(f"GtRNAdb FASTA Download Tool")
+    print("GtRNAdb FASTA Download Tool")
     print(f"{'='*80}")
     print(f"Mode: {'MANUAL URLS ONLY' if args.manual else 'AUTOMATED DOWNLOAD'}")
     print(f"Organisms: {len(organisms)}")
@@ -280,12 +282,12 @@ def main():
 
     # Summary
     print(f"\n\n{'='*80}")
-    print(f"DOWNLOAD SUMMARY")
+    print("DOWNLOAD SUMMARY")
     print(f"{'='*80}")
 
     successful = [r for r in results if r['success']]
     failed = [r for r in results if not r['success'] and not r.get('manual')]
-    manual = [r for r in results if r.get('manual')]
+    # Note: 'manual' results are those where --manual flag was used
 
     print(f"\nTotal organisms: {len(results)}")
     print(f"Already exist: {len([r for r in successful if r.get('already_exists')])}")
@@ -293,10 +295,10 @@ def main():
     print(f"Failed (manual download required): {len(failed)}")
 
     if failed:
-        print(f"\n⚠️  Manual download required for:")
+        print("\n⚠️  Manual download required for:")
         for r in failed:
             print(f"   - {r['organism_name']}")
-        print(f"\nVisit http://gtrnadb.ucsc.edu/ to download these organisms manually.")
+        print("\nVisit http://gtrnadb.ucsc.edu/ to download these organisms manually.")
 
     print(f"\n{'='*80}\n")
 

--- a/scripts/download_gtrnadb_fastas.py
+++ b/scripts/download_gtrnadb_fastas.py
@@ -22,11 +22,12 @@ Examples:
 import argparse
 import os
 import sys
-import urllib.request
-import urllib.error
-from pathlib import Path
-import yaml
 import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
 
 # Ensure we're in the project root
 PROJECT_ROOT = Path(__file__).parent.parent

--- a/scripts/fix_e_position_global_index.py
+++ b/scripts/fix_e_position_global_index.py
@@ -16,7 +16,7 @@ import pandas as pd
 
 # Add scripts directory to path
 sys.path.insert(0, os.path.dirname(__file__))
-import trnas_in_space
+import trnas_in_space  # noqa: E402
 
 PRECISION = 6  # Must match PRECISION in trnas_in_space.py
 
@@ -46,7 +46,7 @@ def fix_global_index(input_tsv: str, output_tsv: str):
     to_ord = {u: i + 1 for i, u in enumerate(uniq)}
 
     print(f"  Unique labels: {len(uniq)}")
-    print(f"  Sample labels around position 47-48:")
+    print("  Sample labels around position 47-48:")
     for i, label in enumerate(uniq):
         if label in ["44", "45", "46", "47", "48", "49"] or label.startswith("e"):
             print(f"    {i+1:3d}: {label}")

--- a/scripts/fix_e_position_global_index.py
+++ b/scripts/fix_e_position_global_index.py
@@ -10,8 +10,9 @@ Usage:
     python scripts/fix_e_position_global_index.py <input.tsv> <output.tsv>
 """
 
-import sys
 import os
+import sys
+
 import pandas as pd
 
 # Add scripts directory to path

--- a/scripts/fix_e_position_global_index.py
+++ b/scripts/fix_e_position_global_index.py
@@ -29,7 +29,7 @@ def fix_global_index(input_tsv: str, output_tsv: str):
     sort_key function, and writes the corrected output.
     """
     print(f"Reading {input_tsv}...")
-    df = pd.read_csv(input_tsv, sep='\t')
+    df = pd.read_csv(input_tsv, sep="\t")
 
     print(f"  Rows: {len(df)}")
     print(f"  tRNAs: {df['trna_id'].nunique()}")

--- a/scripts/generate_alignment_inspection.py
+++ b/scripts/generate_alignment_inspection.py
@@ -17,41 +17,43 @@ def generate_alignment_inspection(input_file, output_file):
         output_file: Path to the output TSV file
     """
     # Read the input TSV
-    df = pd.read_csv(input_file, sep='\t')
+    df = pd.read_csv(input_file, sep="\t")
 
     # Create a pivot table
     # Rows: trna_id, Columns: global_index, Values: sprinzl_label
     pivot = df.pivot_table(
-        index='trna_id',
-        columns='global_index',
-        values='sprinzl_label',
-        aggfunc='first'  # In case of duplicates, take the first
+        index="trna_id",
+        columns="global_index",
+        values="sprinzl_label",
+        aggfunc="first",  # In case of duplicates, take the first
     )
 
     # Ensure all global_index values from min to max are present
     min_idx = int(pivot.columns.min())
     max_idx = int(pivot.columns.max())
     full_columns = range(min_idx, max_idx + 1)
-    pivot = pivot.reindex(columns=full_columns, fill_value='NA')
+    pivot = pivot.reindex(columns=full_columns, fill_value="NA")
 
     # Fill missing values with 'NA'
-    pivot = pivot.fillna('NA')
+    pivot = pivot.fillna("NA")
 
     # Sort rows (tRNA IDs) alphabetically
     pivot = pivot.sort_index()
 
     # Reset index to make trna_id a column
     pivot = pivot.reset_index()
-    pivot = pivot.rename(columns={'trna_id': 'tRNA'})
+    pivot = pivot.rename(columns={"trna_id": "tRNA"})
 
     # Save to TSV
-    pivot.to_csv(output_file, sep='\t', index=False)
+    pivot.to_csv(output_file, sep="\t", index=False)
 
     print(f"Generated alignment inspection file: {output_file}")
-    print(f"Dimensions: {len(pivot)} rows (tRNAs) × {len(pivot.columns)-1} columns (global_index positions)")
+    print(
+        f"Dimensions: {len(pivot)} rows (tRNAs) × {len(pivot.columns)-1} columns (global_index positions)"
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if len(sys.argv) != 3:
         print("Usage: python generate_alignment_inspection.py <input_tsv> <output_tsv>")
         sys.exit(1)

--- a/scripts/generate_alignment_inspection.py
+++ b/scripts/generate_alignment_inspection.py
@@ -7,6 +7,7 @@ Pivots the data to show global_index as rows and tRNA IDs as columns.
 import pandas as pd
 import sys
 
+
 def generate_alignment_inspection(input_file, output_file):
     """
     Transform the global coordinates TSV for alignment inspection.
@@ -48,6 +49,7 @@ def generate_alignment_inspection(input_file, output_file):
 
     print(f"Generated alignment inspection file: {output_file}")
     print(f"Dimensions: {len(pivot)} rows (tRNAs) × {len(pivot.columns)-1} columns (global_index positions)")
+
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:

--- a/scripts/generate_alignment_inspection.py
+++ b/scripts/generate_alignment_inspection.py
@@ -4,8 +4,9 @@ Generate a transformed TSV view for manual inspection of tRNA alignments.
 Pivots the data to show global_index as rows and tRNA IDs as columns.
 """
 
-import pandas as pd
 import sys
+
+import pandas as pd
 
 
 def generate_alignment_inspection(input_file, output_file):

--- a/scripts/modomics/align_to_sprinzl.py
+++ b/scripts/modomics/align_to_sprinzl.py
@@ -19,6 +19,7 @@ try:
 except ImportError:
     print("ERROR: BioPython not installed. Run: pip install biopython")
     import sys
+
     sys.exit(1)
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class AlignmentResult:
     """Result of aligning a Modomics tRNA to a gtRNAdb tRNA."""
+
     modomics_id: int
     modomics_name: str
     gtRNAdb_trna_id: str
@@ -40,6 +42,7 @@ class AlignmentResult:
 @dataclass
 class SprinzlMapping:
     """Complete mapping from Modomics modification to Sprinzl position."""
+
     modomics_id: int
     modomics_name: str
     species: str
@@ -64,11 +67,11 @@ class SpeciesNameMapper:
 
     # Manual mapping for key species
     SPECIES_MAP = {
-        'Escherichia coli': 'ecoliK12',
-        'Escherichia coli K-12': 'ecoliK12',
-        'Escherichia coli str. K-12': 'ecoliK12',
-        'Saccharomyces cerevisiae': 'sacCer',
-        'Homo sapiens': 'hg38',
+        "Escherichia coli": "ecoliK12",
+        "Escherichia coli K-12": "ecoliK12",
+        "Escherichia coli str. K-12": "ecoliK12",
+        "Saccharomyces cerevisiae": "sacCer",
+        "Homo sapiens": "hg38",
     }
 
     @classmethod
@@ -87,14 +90,14 @@ class AnticodonNormalizer:
 
     # Map modified anticodon codes to canonical bases
     MODIFIED_BASES = {
-        'I': 'G',  # Inosine
-        'V': 'U',  # Various uridine modifications
-        'Y': 'U',  # Pseudouridine
-        'D': 'U',  # Dihydrouridine
-        'T': 'U',  # Ribothymidine
-        'm1G': 'G',
-        'm2G': 'G',
-        'm7G': 'G',
+        "I": "G",  # Inosine
+        "V": "U",  # Various uridine modifications
+        "Y": "U",  # Pseudouridine
+        "D": "U",  # Dihydrouridine
+        "T": "U",  # Ribothymidine
+        "m1G": "G",
+        "m2G": "G",
+        "m7G": "G",
     }
 
     @classmethod
@@ -113,8 +116,8 @@ class AnticodonNormalizer:
             normalized = normalized.replace(mod, canonical)
 
         # Remove any remaining non-standard characters
-        valid = set('ACGU')
-        normalized = ''.join(c if c in valid else 'N' for c in normalized)
+        valid = set("ACGU")
+        normalized = "".join(c if c in valid else "N" for c in normalized)
 
         return normalized
 
@@ -159,7 +162,9 @@ class GTRNAdbLoader:
                 break
 
         if not fasta_file:
-            raise FileNotFoundError(f"Could not find FASTA file for {organism_id} in {self.fasta_dir}")
+            raise FileNotFoundError(
+                f"Could not find FASTA file for {organism_id} in {self.fasta_dir}"
+            )
 
         logger.info(f"Loading FASTA: {fasta_file}")
 
@@ -167,17 +172,17 @@ class GTRNAdbLoader:
         current_id = None
         current_seq: list[str] = []
 
-        with open(fasta_file, 'r') as f:
+        with open(fasta_file, "r") as f:
             for line in f:
                 line = line.strip()
                 if not line:
                     continue
 
-                if line.startswith('>'):
+                if line.startswith(">"):
                     # Save previous sequence
                     if current_id:
                         # Convert DNA (T) to RNA (U)
-                        seq = ''.join(current_seq).replace('T', 'U')
+                        seq = "".join(current_seq).replace("T", "U")
                         sequences[current_id] = seq
 
                     # Start new sequence
@@ -188,7 +193,7 @@ class GTRNAdbLoader:
 
             # Save last sequence
             if current_id:
-                seq = ''.join(current_seq).replace('T', 'U')
+                seq = "".join(current_seq).replace("T", "U")
                 sequences[current_id] = seq
 
         logger.info(f"Loaded {len(sequences)} tRNA sequences")
@@ -213,17 +218,19 @@ class GTRNAdbLoader:
 
         coords = defaultdict(list)
 
-        with open(coords_file, 'r') as f:
-            reader = csv.DictReader(f, delimiter='\t')
+        with open(coords_file, "r") as f:
+            reader = csv.DictReader(f, delimiter="\t")
             for row in reader:
-                trna_id = row['trna_id']
-                coords[trna_id].append({
-                    'seq_index': int(row['seq_index']),
-                    'sprinzl_index': int(row['sprinzl_index']),
-                    'sprinzl_label': row['sprinzl_label'],
-                    'residue': row['residue'],
-                    'region': row['region'],
-                })
+                trna_id = row["trna_id"]
+                coords[trna_id].append(
+                    {
+                        "seq_index": int(row["seq_index"]),
+                        "sprinzl_index": int(row["sprinzl_index"]),
+                        "sprinzl_label": row["sprinzl_label"],
+                        "residue": row["residue"],
+                        "region": row["region"],
+                    }
+                )
 
         logger.info(f"Loaded coordinates for {len(coords)} tRNAs")
         return dict(coords)
@@ -232,8 +239,9 @@ class GTRNAdbLoader:
 class ModomicsAligner:
     """Aligns Modomics tRNA sequences to gtRNAdb sequences."""
 
-    def __init__(self, match: int = 2, mismatch: int = -1,
-                 gap_open: float = -2, gap_extend: float = -0.5):
+    def __init__(
+        self, match: int = 2, mismatch: int = -1, gap_open: float = -2, gap_extend: float = -0.5
+    ):
         """
         Initialize aligner with scoring parameters.
 
@@ -260,10 +268,13 @@ class ModomicsAligner:
             Tuple of (aligned_seq1, aligned_seq2, score)
         """
         alignments = pairwise2.align.globalms(
-            seq1, seq2,
-            self.match, self.mismatch,
-            self.gap_open, self.gap_extend,
-            one_alignment_only=True
+            seq1,
+            seq2,
+            self.match,
+            self.mismatch,
+            self.gap_open,
+            self.gap_extend,
+            one_alignment_only=True,
         )
 
         if not alignments:
@@ -283,15 +294,17 @@ class ModomicsAligner:
         Returns:
             Identity as percentage (0-100)
         """
-        matches = sum(1 for a, b in zip(aligned1, aligned2) if a == b and a != '-')
-        total = len([c for c in aligned1 if c != '-'])
+        matches = sum(1 for a, b in zip(aligned1, aligned2) if a == b and a != "-")
+        total = len([c for c in aligned1 if c != "-"])
 
         if total == 0:
             return 0.0
 
         return (matches / total) * 100.0
 
-    def create_position_mapping(self, aligned_modomics: str, aligned_gtRNAdb: str) -> Dict[int, int]:
+    def create_position_mapping(
+        self, aligned_modomics: str, aligned_gtRNAdb: str
+    ) -> Dict[int, int]:
         """
         Create mapping from Modomics positions to gtRNAdb positions.
 
@@ -307,21 +320,24 @@ class ModomicsAligner:
         gtRNAdb_pos = 0
 
         for mod_char, gtR_char in zip(aligned_modomics, aligned_gtRNAdb):
-            if mod_char != '-':
+            if mod_char != "-":
                 modomics_pos += 1
-            if gtR_char != '-':
+            if gtR_char != "-":
                 gtRNAdb_pos += 1
 
             # Only map if both positions are not gaps
-            if mod_char != '-' and gtR_char != '-':
+            if mod_char != "-" and gtR_char != "-":
                 mapping[modomics_pos] = gtRNAdb_pos
 
         return mapping
 
     def find_best_match(
-        self, modomics_seq: str, modomics_anticodon: str,
-        modomics_subtype: str, gtRNAdb_sequences: Dict[str, str],
-        min_identity: float = 80.0
+        self,
+        modomics_seq: str,
+        modomics_anticodon: str,
+        modomics_subtype: str,
+        gtRNAdb_sequences: Dict[str, str],
+        min_identity: float = 80.0,
     ) -> Optional[AlignmentResult]:
         """
         Find best matching gtRNAdb sequence for a Modomics tRNA.
@@ -340,7 +356,7 @@ class ModomicsAligner:
         norm_anticodon = AnticodonNormalizer.normalize(modomics_anticodon)
 
         best_result = None
-        best_score = -float('inf')
+        best_score = -float("inf")
 
         for trna_id, gtRNAdb_seq in gtRNAdb_sequences.items():
             # Quick filter: check if anticodon and subtype match
@@ -348,10 +364,10 @@ class ModomicsAligner:
             #   tRNA-{Subtype}-{Anticodon}-{Copy}-{Variant}  (E. coli)
             #   nuc-tRNA-{Subtype}-{Anticodon}-{Copy}-{Variant}  (yeast/human nuclear)
             #   mito-tRNA-{Subtype}-{Anticodon}-{Copy}-{Variant}  (yeast/human mito)
-            parts = trna_id.split('-')
+            parts = trna_id.split("-")
 
             # Handle prefix (nuc-, mito-, or no prefix)
-            if parts[0] in ['nuc', 'mito']:
+            if parts[0] in ["nuc", "mito"]:
                 # Format: nuc-tRNA-Ala-AGC-1-1
                 if len(parts) >= 5:
                     gtR_subtype = parts[2]
@@ -385,13 +401,13 @@ class ModomicsAligner:
 
                 best_result = AlignmentResult(
                     modomics_id=0,  # Will be filled by caller
-                    modomics_name='',  # Will be filled by caller
+                    modomics_name="",  # Will be filled by caller
                     gtRNAdb_trna_id=trna_id,
                     alignment_score=score,
                     alignment_identity=identity,
                     aligned_modomics=aligned_mod,
                     aligned_gtRNAdb=aligned_gtR,
-                    position_mapping=position_mapping
+                    position_mapping=position_mapping,
                 )
 
         return best_result
@@ -414,12 +430,14 @@ class SprinzlMapper:
         self.aligner = ModomicsAligner()
 
         # Load Modomics data
-        with open(self.modomics_json, 'r') as f:
+        with open(self.modomics_json, "r") as f:
             self.modomics_data = json.load(f)
 
         logger.info(f"Loaded {len(self.modomics_data)} Modomics tRNAs")
 
-    def process_species(self, modomics_species: str, min_identity: float = 80.0) -> List[SprinzlMapping]:
+    def process_species(
+        self, modomics_species: str, min_identity: float = 80.0
+    ) -> List[SprinzlMapping]:
         """
         Process all tRNAs for a species and create Sprinzl mappings.
 
@@ -450,7 +468,7 @@ class SprinzlMapper:
         species_trnas = {
             trna_id: trna_data
             for trna_id, trna_data in self.modomics_data.items()
-            if trna_data['species'] == modomics_species
+            if trna_data["species"] == modomics_species
         }
 
         logger.info(f"Found {len(species_trnas)} Modomics tRNAs for {modomics_species}")
@@ -461,25 +479,27 @@ class SprinzlMapper:
 
         for trna_id, trna_data in species_trnas.items():
             # Skip if no unmodified sequence
-            if not trna_data.get('unmodified_sequence'):
+            if not trna_data.get("unmodified_sequence"):
                 logger.warning(f"Skipping {trna_data['name']}: no unmodified sequence")
                 continue
 
             # Skip if no modifications
-            if not trna_data.get('modifications'):
+            if not trna_data.get("modifications"):
                 continue
 
             # Find best alignment
             alignment = self.aligner.find_best_match(
-                modomics_seq=trna_data['unmodified_sequence'],
-                modomics_anticodon=trna_data['anticodon'],
-                modomics_subtype=trna_data['subtype'],
+                modomics_seq=trna_data["unmodified_sequence"],
+                modomics_anticodon=trna_data["anticodon"],
+                modomics_subtype=trna_data["subtype"],
                 gtRNAdb_sequences=gtRNAdb_sequences,
-                min_identity=min_identity
+                min_identity=min_identity,
             )
 
             if not alignment:
-                logger.debug(f"No alignment for {trna_data['name']} ({trna_data['subtype']}-{trna_data['anticodon']})")
+                logger.debug(
+                    f"No alignment for {trna_data['name']} ({trna_data['subtype']}-{trna_data['anticodon']})"
+                )
                 continue
 
             aligned_count += 1
@@ -492,8 +512,8 @@ class SprinzlMapper:
             coords = global_coords[alignment.gtRNAdb_trna_id]
 
             # Map each modification
-            for mod in trna_data['modifications']:
-                modomics_pos = mod['position']
+            for mod in trna_data["modifications"]:
+                modomics_pos = mod["position"]
 
                 # Get gtRNAdb position from alignment
                 if modomics_pos not in alignment.position_mapping:
@@ -505,7 +525,7 @@ class SprinzlMapper:
                 # Find Sprinzl position
                 sprinzl_info = None
                 for coord in coords:
-                    if coord['seq_index'] == gtRNAdb_pos:
+                    if coord["seq_index"] == gtRNAdb_pos:
                         sprinzl_info = coord
                         break
 
@@ -516,22 +536,22 @@ class SprinzlMapper:
                 # Create mapping
                 mapping = SprinzlMapping(
                     modomics_id=int(trna_id),
-                    modomics_name=trna_data['name'],
+                    modomics_name=trna_data["name"],
                     species=modomics_species,
-                    trna_type=trna_data['subtype'],
-                    anticodon=trna_data['anticodon'],
+                    trna_type=trna_data["subtype"],
+                    anticodon=trna_data["anticodon"],
                     gtRNAdb_trna_id=alignment.gtRNAdb_trna_id,
                     alignment_score=alignment.alignment_score,
                     alignment_identity=alignment.alignment_identity,
                     modification_position_modomics=modomics_pos,
-                    modification_char=mod['modified_char'],
-                    modification_name=mod.get('modification_name', 'Unknown'),
-                    modification_short_name=mod.get('short_name', ''),
-                    unmodified_char=mod['unmodified_char'],
+                    modification_char=mod["modified_char"],
+                    modification_name=mod.get("modification_name", "Unknown"),
+                    modification_short_name=mod.get("short_name", ""),
+                    unmodified_char=mod["unmodified_char"],
                     position_gtRNAdb=gtRNAdb_pos,
-                    sprinzl_index=sprinzl_info['sprinzl_index'],
-                    sprinzl_label=sprinzl_info['sprinzl_label'],
-                    region=sprinzl_info['region']
+                    sprinzl_index=sprinzl_info["sprinzl_index"],
+                    sprinzl_label=sprinzl_info["sprinzl_label"],
+                    region=sprinzl_info["region"],
                 )
 
                 mappings.append(mapping)
@@ -553,49 +573,51 @@ class SprinzlMapper:
         out_path.parent.mkdir(parents=True, exist_ok=True)
 
         fieldnames = [
-            'modomics_id',
-            'modomics_name',
-            'species',
-            'trna_type',
-            'anticodon',
-            'gtRNAdb_trna_id',
-            'alignment_score',
-            'alignment_identity',
-            'modification_position_modomics',
-            'modification_char',
-            'modification_name',
-            'modification_short_name',
-            'unmodified_char',
-            'position_gtRNAdb',
-            'sprinzl_index',
-            'sprinzl_label',
-            'region'
+            "modomics_id",
+            "modomics_name",
+            "species",
+            "trna_type",
+            "anticodon",
+            "gtRNAdb_trna_id",
+            "alignment_score",
+            "alignment_identity",
+            "modification_position_modomics",
+            "modification_char",
+            "modification_name",
+            "modification_short_name",
+            "unmodified_char",
+            "position_gtRNAdb",
+            "sprinzl_index",
+            "sprinzl_label",
+            "region",
         ]
 
-        with open(out_path, 'w', newline='') as f:
-            writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter='\t')
+        with open(out_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t")
             writer.writeheader()
 
             for mapping in mappings:
-                writer.writerow({
-                    'modomics_id': mapping.modomics_id,
-                    'modomics_name': mapping.modomics_name,
-                    'species': mapping.species,
-                    'trna_type': mapping.trna_type,
-                    'anticodon': mapping.anticodon,
-                    'gtRNAdb_trna_id': mapping.gtRNAdb_trna_id,
-                    'alignment_score': f"{mapping.alignment_score:.1f}",
-                    'alignment_identity': f"{mapping.alignment_identity:.1f}",
-                    'modification_position_modomics': mapping.modification_position_modomics,
-                    'modification_char': mapping.modification_char,
-                    'modification_name': mapping.modification_name,
-                    'modification_short_name': mapping.modification_short_name,
-                    'unmodified_char': mapping.unmodified_char,
-                    'position_gtRNAdb': mapping.position_gtRNAdb,
-                    'sprinzl_index': mapping.sprinzl_index,
-                    'sprinzl_label': mapping.sprinzl_label,
-                    'region': mapping.region
-                })
+                writer.writerow(
+                    {
+                        "modomics_id": mapping.modomics_id,
+                        "modomics_name": mapping.modomics_name,
+                        "species": mapping.species,
+                        "trna_type": mapping.trna_type,
+                        "anticodon": mapping.anticodon,
+                        "gtRNAdb_trna_id": mapping.gtRNAdb_trna_id,
+                        "alignment_score": f"{mapping.alignment_score:.1f}",
+                        "alignment_identity": f"{mapping.alignment_identity:.1f}",
+                        "modification_position_modomics": mapping.modification_position_modomics,
+                        "modification_char": mapping.modification_char,
+                        "modification_name": mapping.modification_name,
+                        "modification_short_name": mapping.modification_short_name,
+                        "unmodified_char": mapping.unmodified_char,
+                        "position_gtRNAdb": mapping.position_gtRNAdb,
+                        "sprinzl_index": mapping.sprinzl_index,
+                        "sprinzl_label": mapping.sprinzl_label,
+                        "region": mapping.region,
+                    }
+                )
 
         logger.info(f"Exported {len(mappings)} mappings to {out_path}")
 
@@ -605,56 +627,39 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(
-        description='Align Modomics tRNAs to gtRNAdb and map to Sprinzl positions'
+        description="Align Modomics tRNAs to gtRNAdb and map to Sprinzl positions"
     )
     parser.add_argument(
-        '--modomics-json',
-        required=True,
-        help='Path to modomics_modifications.json'
+        "--modomics-json", required=True, help="Path to modomics_modifications.json"
     )
     parser.add_argument(
-        '--fasta-dir',
-        default='fastas',
-        help='Directory containing gtRNAdb FASTA files'
+        "--fasta-dir", default="fastas", help="Directory containing gtRNAdb FASTA files"
     )
     parser.add_argument(
-        '--output-dir',
-        default='outputs',
-        help='Directory containing global_coords.tsv files'
+        "--output-dir", default="outputs", help="Directory containing global_coords.tsv files"
     )
     parser.add_argument(
-        '--species',
-        help='Species to process (Modomics format, e.g., "Escherichia coli")'
+        "--species", help='Species to process (Modomics format, e.g., "Escherichia coli")'
     )
+    parser.add_argument("--all-species", action="store_true", help="Process all supported species")
+    parser.add_argument("--output", help="Output TSV file path")
     parser.add_argument(
-        '--all-species',
-        action='store_true',
-        help='Process all supported species'
-    )
-    parser.add_argument(
-        '--output',
-        help='Output TSV file path'
-    )
-    parser.add_argument(
-        '--min-identity',
+        "--min-identity",
         type=float,
         default=80.0,
-        help='Minimum alignment identity threshold (default: 80.0)'
+        help="Minimum alignment identity threshold (default: 80.0)",
     )
 
     args = parser.parse_args()
 
     # Setup logging
     logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
 
     # Initialize mapper
     mapper = SprinzlMapper(
-        modomics_json=args.modomics_json,
-        fasta_dir=args.fasta_dir,
-        output_dir=args.output_dir
+        modomics_json=args.modomics_json, fasta_dir=args.fasta_dir, output_dir=args.output_dir
     )
 
     # Determine which species to process
@@ -674,7 +679,7 @@ def main():
 
     # Export results
     if all_mappings:
-        output_path = args.output or 'outputs/modomics/modomics_to_sprinzl_mapping.tsv'
+        output_path = args.output or "outputs/modomics/modomics_to_sprinzl_mapping.tsv"
         mapper.export_to_tsv(all_mappings, output_path)
 
         print(f"\n✓ Successfully created {len(all_mappings)} modification→Sprinzl mappings")
@@ -686,6 +691,7 @@ def main():
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
+
     sys.exit(main())

--- a/scripts/modomics/align_to_sprinzl.py
+++ b/scripts/modomics/align_to_sprinzl.py
@@ -16,7 +16,6 @@ from collections import defaultdict
 
 try:
     from Bio import pairwise2
-    from Bio.pairwise2 import format_alignment
 except ImportError:
     print("ERROR: BioPython not installed. Run: pip install biopython")
     import sys
@@ -166,7 +165,7 @@ class GTRNAdbLoader:
 
         sequences = {}
         current_id = None
-        current_seq = []
+        current_seq: list[str] = []
 
         with open(fasta_file, 'r') as f:
             for line in f:
@@ -319,9 +318,11 @@ class ModomicsAligner:
 
         return mapping
 
-    def find_best_match(self, modomics_seq: str, modomics_anticodon: str,
-                       modomics_subtype: str, gtRNAdb_sequences: Dict[str, str],
-                       min_identity: float = 80.0) -> Optional[AlignmentResult]:
+    def find_best_match(
+        self, modomics_seq: str, modomics_anticodon: str,
+        modomics_subtype: str, gtRNAdb_sequences: Dict[str, str],
+        min_identity: float = 80.0
+    ) -> Optional[AlignmentResult]:
         """
         Find best matching gtRNAdb sequence for a Modomics tRNA.
 
@@ -548,8 +549,8 @@ class SprinzlMapper:
             mappings: List of SprinzlMapping objects
             output_path: Output TSV file path
         """
-        output_path = Path(output_path)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path = Path(output_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
 
         fieldnames = [
             'modomics_id',
@@ -571,7 +572,7 @@ class SprinzlMapper:
             'region'
         ]
 
-        with open(output_path, 'w', newline='') as f:
+        with open(out_path, 'w', newline='') as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter='\t')
             writer.writeheader()
 
@@ -596,7 +597,7 @@ class SprinzlMapper:
                     'region': mapping.region
                 })
 
-        logger.info(f"Exported {len(mappings)} mappings to {output_path}")
+        logger.info(f"Exported {len(mappings)} mappings to {out_path}")
 
 
 def main():

--- a/scripts/modomics/align_to_sprinzl.py
+++ b/scripts/modomics/align_to_sprinzl.py
@@ -6,13 +6,13 @@ This module aligns Modomics tRNA sequences to gtRNAdb sequences
 and maps modification positions to Sprinzl coordinates.
 """
 
-import json
 import csv
+import json
 import logging
+from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
-from dataclasses import dataclass
-from collections import defaultdict
 
 try:
     from Bio import pairwise2

--- a/scripts/modomics/modification_codes.py
+++ b/scripts/modomics/modification_codes.py
@@ -10,7 +10,7 @@ This module provides functions to:
 
 import csv
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional
 import logging
 
 logger = logging.getLogger(__name__)

--- a/scripts/modomics/modification_codes.py
+++ b/scripts/modomics/modification_codes.py
@@ -9,9 +9,9 @@ This module provides functions to:
 """
 
 import csv
+import logging
 from pathlib import Path
 from typing import Dict, Optional
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/modomics/modification_codes.py
+++ b/scripts/modomics/modification_codes.py
@@ -38,32 +38,34 @@ class ModificationCodec:
         if not self.codes_csv_path.exists():
             raise FileNotFoundError(f"Modification codes file not found: {self.codes_csv_path}")
 
-        with open(self.codes_csv_path, 'r', encoding='utf-8') as f:
+        with open(self.codes_csv_path, "r", encoding="utf-8") as f:
             reader = csv.DictReader(f)
             for row in reader:
-                code = row.get('RNAMods code (2023)', '').strip()
+                code = row.get("RNAMods code (2023)", "").strip()
                 if not code:
                     logger.warning(f"Skipping row with empty code: {row}")
                     continue
 
                 info = {
-                    'name': row.get('Name', '').strip(),
-                    'short_name': row.get('Short Name', '').strip(),
-                    'modomics_code_new': row.get('MODOMICS code new (2023)', '').strip(),
-                    'moiety_type': row.get('Moiety type', '').strip(),
-                    'reference_base': row.get('Reference NucleoBase', '').strip(),
-                    'modomics_db_id': row.get('MODOMICS Database ID', '').strip(),
+                    "name": row.get("Name", "").strip(),
+                    "short_name": row.get("Short Name", "").strip(),
+                    "modomics_code_new": row.get("MODOMICS code new (2023)", "").strip(),
+                    "moiety_type": row.get("Moiety type", "").strip(),
+                    "reference_base": row.get("Reference NucleoBase", "").strip(),
+                    "modomics_db_id": row.get("MODOMICS Database ID", "").strip(),
                 }
 
                 self.code_to_info[code] = info
 
                 # Build reverse lookups
-                if info['name']:
-                    self.name_to_code[info['name']] = code
-                if info['short_name']:
-                    self.short_name_to_code[info['short_name']] = code
+                if info["name"]:
+                    self.name_to_code[info["name"]] = code
+                if info["short_name"]:
+                    self.short_name_to_code[info["short_name"]] = code
 
-        logger.info(f"Loaded {len(self.code_to_info)} modification codes from {self.codes_csv_path}")
+        logger.info(
+            f"Loaded {len(self.code_to_info)} modification codes from {self.codes_csv_path}"
+        )
 
     def decode(self, code: str) -> Optional[dict]:
         """
@@ -88,7 +90,7 @@ class ModificationCodec:
             Full modification name, or None if not found
         """
         info = self.decode(code)
-        return info['name'] if info else None
+        return info["name"] if info else None
 
     def get_short_name(self, code: str) -> Optional[str]:
         """
@@ -101,7 +103,7 @@ class ModificationCodec:
             Short modification name (e.g., "m1A", "Y"), or None if not found
         """
         info = self.decode(code)
-        return info['short_name'] if info else None
+        return info["short_name"] if info else None
 
     def get_reference_base(self, code: str) -> Optional[str]:
         """
@@ -114,7 +116,7 @@ class ModificationCodec:
             Reference base (A, C, G, or U), or None if not found
         """
         info = self.decode(code)
-        return info['reference_base'] if info else None
+        return info["reference_base"] if info else None
 
     def encode(self, name: str) -> Optional[str]:
         """
@@ -156,7 +158,7 @@ class ModificationCodec:
         Returns:
             True if the character is A, C, G, or U
         """
-        return char.upper() in ['A', 'C', 'G', 'U']
+        return char.upper() in ["A", "C", "G", "U"]
 
     def get_all_codes(self) -> list:
         """Get list of all known modification codes."""
@@ -164,18 +166,18 @@ class ModificationCodec:
 
     def get_statistics(self) -> dict:
         """Get statistics about loaded modifications."""
-        base_counts = {'A': 0, 'C': 0, 'G': 0, 'U': 0, 'Unknown': 0}
+        base_counts = {"A": 0, "C": 0, "G": 0, "U": 0, "Unknown": 0}
 
         for info in self.code_to_info.values():
-            ref_base = info.get('reference_base', 'Unknown')
+            ref_base = info.get("reference_base", "Unknown")
             if ref_base in base_counts:
                 base_counts[ref_base] += 1
             else:
-                base_counts['Unknown'] += 1
+                base_counts["Unknown"] += 1
 
         return {
-            'total_modifications': len(self.code_to_info),
-            'by_reference_base': base_counts,
+            "total_modifications": len(self.code_to_info),
+            "by_reference_base": base_counts,
         }
 
 
@@ -192,14 +194,14 @@ def load_modification_codec(codes_csv_path: str) -> ModificationCodec:
     return ModificationCodec(codes_csv_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Test the codec
     import sys
 
     if len(sys.argv) > 1:
         codec_path = sys.argv[1]
     else:
-        codec_path = 'docs/development/modomicscodes.csv'
+        codec_path = "docs/development/modomicscodes.csv"
 
     logging.basicConfig(level=logging.INFO)
     codec = load_modification_codec(codec_path)
@@ -208,12 +210,12 @@ if __name__ == '__main__':
     stats = codec.get_statistics()
     print(f"Total modifications: {stats['total_modifications']}")
     print("\nBy reference base:")
-    for base, count in stats['by_reference_base'].items():
+    for base, count in stats["by_reference_base"].items():
         print(f"  {base}: {count}")
 
     print("\n=== Example Lookups ===")
     # Test with some example codes that should be in the file
-    test_codes = ['D', 'T', 'Y', 'K', 'Ѣ']
+    test_codes = ["D", "T", "Y", "K", "Ѣ"]
     for code in test_codes:
         info = codec.decode(code)
         if info:

--- a/scripts/modomics/parse_modomics.py
+++ b/scripts/modomics/parse_modomics.py
@@ -9,10 +9,9 @@ This module provides functions to:
 - Generate structured output for downstream analysis
 """
 
-import re
 import json
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 from dataclasses import dataclass, asdict
 import logging
 
@@ -98,15 +97,15 @@ class ModomicsParser:
         Returns:
             Dictionary mapping modomics_id to ModomicsTRNA objects
         """
-        fasta_path = Path(fasta_path)
-        if not fasta_path.exists():
-            raise FileNotFoundError(f"FASTA file not found: {fasta_path}")
+        path = Path(fasta_path)
+        if not path.exists():
+            raise FileNotFoundError(f"FASTA file not found: {path}")
 
         trnas = {}
         current_header = None
-        current_sequence = []
+        current_sequence: list[str] = []
 
-        with open(fasta_path, 'r', encoding='utf-8') as f:
+        with open(path, 'r', encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
                 if not line:
@@ -158,12 +157,14 @@ class ModomicsParser:
 
                 trnas[metadata['modomics_id']] = trna
 
-        logger.info(f"Parsed {len(trnas)} tRNA sequences from {fasta_path}")
+        logger.info(f"Parsed {len(trnas)} tRNA sequences from {path}")
         return trnas
 
-    def merge_sequences(self,
-                       modified_trnas: Dict[int, ModomicsTRNA],
-                       unmodified_trnas: Dict[int, ModomicsTRNA]) -> Dict[int, ModomicsTRNA]:
+    def merge_sequences(
+        self,
+        modified_trnas: Dict[int, ModomicsTRNA],
+        unmodified_trnas: Dict[int, ModomicsTRNA]
+    ) -> Dict[int, ModomicsTRNA]:
         """
         Merge modified and unmodified sequence data.
 
@@ -263,8 +264,8 @@ class ModomicsParser:
             trnas: Dictionary of ModomicsTRNA objects
             output_path: Path for output JSON file
         """
-        output_path = Path(output_path)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path = Path(output_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Convert to serializable format
         data = {
@@ -272,10 +273,10 @@ class ModomicsParser:
             for trna_id, trna in trnas.items()
         }
 
-        with open(output_path, 'w', encoding='utf-8') as f:
+        with open(out_path, 'w', encoding='utf-8') as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
 
-        logger.info(f"Exported {len(trnas)} tRNAs to {output_path}")
+        logger.info(f"Exported {len(trnas)} tRNAs to {out_path}")
 
     def get_species_list(self, trnas: Dict[int, ModomicsTRNA]) -> List[str]:
         """Get sorted list of unique species in the dataset."""
@@ -292,8 +293,8 @@ class ModomicsParser:
         Returns:
             Dictionary with statistics
         """
-        species_counts = {}
-        subtype_counts = {}
+        species_counts: Dict[str, int] = {}
+        subtype_counts: Dict[str, int] = {}
         total_modifications = 0
 
         for trna in trnas.values():
@@ -360,7 +361,7 @@ def parse_modomics_files(modified_fasta: str,
 
     # Print statistics
     stats = parser.get_statistics(trnas)
-    logger.info(f"\n=== Statistics ===")
+    logger.info("\n=== Statistics ===")
     logger.info(f"Total tRNAs: {stats['total_trnas']}")
     logger.info(f"Total species: {stats['total_species']}")
     logger.info(f"Total modifications: {stats['total_modifications']}")
@@ -370,7 +371,6 @@ def parse_modomics_files(modified_fasta: str,
 
 
 if __name__ == '__main__':
-    import sys
     import argparse
 
     parser = argparse.ArgumentParser(description='Parse Modomics tRNA FASTA files')

--- a/scripts/modomics/parse_modomics.py
+++ b/scripts/modomics/parse_modomics.py
@@ -10,10 +10,10 @@ This module provides functions to:
 """
 
 import json
+import logging
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
-from dataclasses import dataclass, asdict
-import logging
 
 from .modification_codes import ModificationCodec
 

--- a/scripts/process_organisms.py
+++ b/scripts/process_organisms.py
@@ -134,7 +134,7 @@ def run_r2dt(organism, fasta_path):
     print("\nThis may take several minutes...\n")
 
     try:
-        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
         print("R2DT completed successfully!")
         return json_output_dir
     except subprocess.CalledProcessError as e:
@@ -234,7 +234,7 @@ def validate_output(output_tsv):
             "file_size_kb": round(output_tsv.stat().st_size / 1024, 2)
         }
 
-        print(f"✓ Valid TSV file")
+        print("✓ Valid TSV file")
         print(f"✓ tRNAs: {n_trnas}")
         print(f"✓ Nucleotides: {n_nucleotides}")
         print(f"✓ Global positions: {n_global_positions}")
@@ -278,7 +278,7 @@ def process_organism(organism, skip_r2dt=False, dry_run=False):
     if not fasta_path:
         print(f"\n❌ ERROR: FASTA file not found for {organism_name}")
         print(f"   Expected in fastas/ with name pattern: {organism['gtrnadb_id']}-tRNAs.fa")
-        print(f"   Please download from GtRNAdb: http://gtrnadb.ucsc.edu/")
+        print("   Please download from GtRNAdb: http://gtrnadb.ucsc.edu/")
         result['error'] = "FASTA file not found"
         return result
 
@@ -366,7 +366,7 @@ def main():
         sys.exit(0)
 
     print(f"\n{'='*80}")
-    print(f"tRNAs in Space - Bulk Organism Processing")
+    print("tRNAs in Space - Bulk Organism Processing")
     print(f"{'='*80}")
     print(f"Mode: {'DRY RUN' if args.dry_run else 'LIVE'}")
     print(f"Skip R2DT: {args.skip_r2dt}")
@@ -386,7 +386,7 @@ def main():
 
     # Summary
     print(f"\n\n{'='*80}")
-    print(f"PROCESSING SUMMARY")
+    print("PROCESSING SUMMARY")
     print(f"{'='*80}")
 
     successful = [r for r in results if r['success']]
@@ -397,7 +397,7 @@ def main():
     print(f"Failed: {len(failed)}")
 
     if successful:
-        print(f"\n✅ Successfully processed:")
+        print("\n✅ Successfully processed:")
         for r in successful:
             print(f"   - {r['organism_name']}")
             if not args.dry_run and 'validation' in r:
@@ -405,7 +405,7 @@ def main():
                 print(f"     {v['n_trnas']} tRNAs, {v['n_nucleotides']} nucleotides, {v['file_size_kb']} KB")
 
     if failed:
-        print(f"\n❌ Failed:")
+        print("\n❌ Failed:")
         for r in failed:
             print(f"   - {r['organism_name']}: {r.get('error', 'Unknown error')}")
 

--- a/scripts/process_organisms.py
+++ b/scripts/process_organisms.py
@@ -29,12 +29,13 @@ Examples:
 """
 
 import argparse
-import os
-import sys
-import subprocess
 import json
-from pathlib import Path
+import os
+import subprocess
+import sys
 from datetime import datetime
+from pathlib import Path
+
 import yaml
 
 # Ensure we're in the project root

--- a/scripts/process_organisms.py
+++ b/scripts/process_organisms.py
@@ -49,7 +49,7 @@ def load_config():
         print(f"Error: Configuration file not found at {config_path}")
         sys.exit(1)
 
-    with open(config_path, 'r') as f:
+    with open(config_path, "r") as f:
         config = yaml.safe_load(f)
 
     return config
@@ -66,24 +66,28 @@ def get_organisms_to_process(config, organism_ids=None):
     Returns:
         List of organism dictionaries to process
     """
-    all_organisms = config['organisms']
+    all_organisms = config["organisms"]
 
     if organism_ids:
         # Process specific organisms
-        organisms = [org for org in all_organisms if org['organism_id'] in organism_ids]
+        organisms = [org for org in all_organisms if org["organism_id"] in organism_ids]
         if not organisms:
             print(f"Error: No organisms found with IDs: {organism_ids}")
             sys.exit(1)
     else:
         # Process all pending organisms (priority 1)
-        organisms = [org for org in all_organisms if org.get('status') == 'pending' and org.get('priority') == 1]
+        organisms = [
+            org
+            for org in all_organisms
+            if org.get("status") == "pending" and org.get("priority") == 1
+        ]
 
     return organisms
 
 
 def check_fasta_exists(organism):
     """Check if FASTA file exists for organism."""
-    gtrnadb_id = organism['gtrnadb_id']
+    gtrnadb_id = organism["gtrnadb_id"]
 
     # Try common naming patterns
     possible_names = [
@@ -110,7 +114,7 @@ def run_r2dt(organism, fasta_path):
     Returns:
         Path to output JSON directory
     """
-    organism_id = organism['organism_id']
+    organism_id = organism["organism_id"]
     json_output_dir = PROJECT_ROOT / "outputs" / "jsons" / organism_id
     json_output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -122,12 +126,17 @@ def run_r2dt(organism, fasta_path):
 
     # Build Docker command
     cmd = [
-        "docker", "run", "--rm",
-        "-v", f"{PROJECT_ROOT}:/data",
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{PROJECT_ROOT}:/data",
         "rnacentral/r2dt",
-        "r2dt.py", "gtrnadb", "draw",
+        "r2dt.py",
+        "gtrnadb",
+        "draw",
         f"/data/{fasta_path}",
-        f"/data/{json_output_dir.relative_to(PROJECT_ROOT)}"
+        f"/data/{json_output_dir.relative_to(PROJECT_ROOT)}",
     ]
 
     print(f"\nCommand: {' '.join(cmd)}")
@@ -155,7 +164,7 @@ def generate_coordinates(organism, json_dir):
     Returns:
         Path to output TSV file
     """
-    organism_id = organism['organism_id']
+    organism_id = organism["organism_id"]
     output_tsv = PROJECT_ROOT / "outputs" / f"{organism_id}_global_coords.tsv"
 
     print(f"\n{'='*80}")
@@ -165,11 +174,7 @@ def generate_coordinates(organism, json_dir):
     print(f"Output TSV: {output_tsv}")
 
     # Build command
-    cmd = [
-        "python", "scripts/trnas_in_space.py",
-        str(json_dir),
-        str(output_tsv)
-    ]
+    cmd = ["python", "scripts/trnas_in_space.py", str(json_dir), str(output_tsv)]
 
     print(f"\nCommand: {' '.join(cmd)}\n")
 
@@ -207,13 +212,20 @@ def validate_output(output_tsv):
     import pandas as pd
 
     try:
-        df = pd.read_csv(output_tsv, sep='\t')
+        df = pd.read_csv(output_tsv, sep="\t")
 
         # Expected columns
         expected_cols = [
-            'trna_id', 'source_file', 'seq_index', 'sprinzl_index',
-            'sprinzl_label', 'residue', 'sprinzl_ordinal',
-            'sprinzl_continuous', 'global_index', 'region'
+            "trna_id",
+            "source_file",
+            "seq_index",
+            "sprinzl_index",
+            "sprinzl_label",
+            "residue",
+            "sprinzl_ordinal",
+            "sprinzl_continuous",
+            "global_index",
+            "region",
         ]
 
         # Check columns
@@ -222,16 +234,16 @@ def validate_output(output_tsv):
             return {"success": False, "error": f"Missing columns: {missing_cols}"}
 
         # Get statistics
-        n_trnas = df['trna_id'].nunique()
+        n_trnas = df["trna_id"].nunique()
         n_nucleotides = len(df)
-        n_global_positions = df['global_index'].max()
+        n_global_positions = df["global_index"].max()
 
         stats = {
             "success": True,
             "n_trnas": n_trnas,
             "n_nucleotides": n_nucleotides,
             "n_global_positions": int(n_global_positions),
-            "file_size_kb": round(output_tsv.stat().st_size / 1024, 2)
+            "file_size_kb": round(output_tsv.stat().st_size / 1024, 2),
         }
 
         print("✓ Valid TSV file")
@@ -259,8 +271,8 @@ def process_organism(organism, skip_r2dt=False, dry_run=False):
     Returns:
         Dictionary with processing results
     """
-    organism_id = organism['organism_id']
-    organism_name = organism['name']
+    organism_id = organism["organism_id"]
+    organism_name = organism["name"]
 
     print(f"\n\n{'#'*80}")
     print(f"# Processing: {organism_name} ({organism_id})")
@@ -270,7 +282,7 @@ def process_organism(organism, skip_r2dt=False, dry_run=False):
         "organism_id": organism_id,
         "organism_name": organism_name,
         "success": False,
-        "steps_completed": []
+        "steps_completed": [],
     }
 
     # Check if FASTA exists
@@ -279,15 +291,15 @@ def process_organism(organism, skip_r2dt=False, dry_run=False):
         print(f"\n❌ ERROR: FASTA file not found for {organism_name}")
         print(f"   Expected in fastas/ with name pattern: {organism['gtrnadb_id']}-tRNAs.fa")
         print("   Please download from GtRNAdb: http://gtrnadb.ucsc.edu/")
-        result['error'] = "FASTA file not found"
+        result["error"] = "FASTA file not found"
         return result
 
     print(f"✓ FASTA file found: {fasta_path}")
-    result['fasta_path'] = fasta_path
+    result["fasta_path"] = fasta_path
 
     if dry_run:
         print("\n[DRY RUN] Would process this organism")
-        result['success'] = True
+        result["success"] = True
         return result
 
     # Run R2DT
@@ -295,36 +307,36 @@ def process_organism(organism, skip_r2dt=False, dry_run=False):
     if not skip_r2dt:
         json_dir = run_r2dt(organism, fasta_path)
         if not json_dir:
-            result['error'] = "R2DT annotation failed"
+            result["error"] = "R2DT annotation failed"
             return result
-        result['steps_completed'].append("r2dt")
+        result["steps_completed"].append("r2dt")
     else:
         # Use existing JSON directory
         json_dir = PROJECT_ROOT / "outputs" / "jsons" / organism_id
         if not json_dir.exists():
             print(f"❌ ERROR: JSON directory not found: {json_dir}")
-            result['error'] = "JSON directory not found (use without --skip-r2dt)"
+            result["error"] = "JSON directory not found (use without --skip-r2dt)"
             return result
         print(f"✓ Using existing JSON directory: {json_dir}")
 
     # Generate coordinates
     output_tsv = generate_coordinates(organism, json_dir)
     if not output_tsv:
-        result['error'] = "Coordinate generation failed"
+        result["error"] = "Coordinate generation failed"
         return result
-    result['steps_completed'].append("coordinates")
-    result['output_tsv'] = str(output_tsv)
+    result["steps_completed"].append("coordinates")
+    result["output_tsv"] = str(output_tsv)
 
     # Validate output
     validation = validate_output(output_tsv)
-    if not validation['success']:
-        result['error'] = f"Validation failed: {validation.get('error')}"
+    if not validation["success"]:
+        result["error"] = f"Validation failed: {validation.get('error')}"
         return result
-    result['steps_completed'].append("validation")
-    result['validation'] = validation
+    result["steps_completed"].append("validation")
+    result["validation"] = validation
 
     # Success!
-    result['success'] = True
+    result["success"] = True
     print(f"\n✅ Successfully processed {organism_name}")
 
     return result
@@ -334,22 +346,20 @@ def main():
     parser = argparse.ArgumentParser(
         description="Bulk process organisms for tRNA global coordinates",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__
+        epilog=__doc__,
     )
     parser.add_argument(
-        '--organisms',
-        help='Comma-separated list of organism IDs to process (default: all pending)',
-        default=None
+        "--organisms",
+        help="Comma-separated list of organism IDs to process (default: all pending)",
+        default=None,
     )
     parser.add_argument(
-        '--skip-r2dt',
-        action='store_true',
-        help='Skip R2DT annotation and use existing JSON files'
+        "--skip-r2dt", action="store_true", help="Skip R2DT annotation and use existing JSON files"
     )
     parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Show what would be processed without actually running'
+        "--dry-run",
+        action="store_true",
+        help="Show what would be processed without actually running",
     )
 
     args = parser.parse_args()
@@ -358,7 +368,7 @@ def main():
     config = load_config()
 
     # Get organisms to process
-    organism_ids = args.organisms.split(',') if args.organisms else None
+    organism_ids = args.organisms.split(",") if args.organisms else None
     organisms = get_organisms_to_process(config, organism_ids)
 
     if not organisms:
@@ -389,8 +399,8 @@ def main():
     print("PROCESSING SUMMARY")
     print(f"{'='*80}")
 
-    successful = [r for r in results if r['success']]
-    failed = [r for r in results if not r['success']]
+    successful = [r for r in results if r["success"]]
+    failed = [r for r in results if not r["success"]]
 
     print(f"\nTotal organisms: {len(results)}")
     print(f"Successful: {len(successful)}")
@@ -400,9 +410,11 @@ def main():
         print("\n✅ Successfully processed:")
         for r in successful:
             print(f"   - {r['organism_name']}")
-            if not args.dry_run and 'validation' in r:
-                v = r['validation']
-                print(f"     {v['n_trnas']} tRNAs, {v['n_nucleotides']} nucleotides, {v['file_size_kb']} KB")
+            if not args.dry_run and "validation" in r:
+                v = r["validation"]
+                print(
+                    f"     {v['n_trnas']} tRNAs, {v['n_nucleotides']} nucleotides, {v['file_size_kb']} KB"
+                )
 
     if failed:
         print("\n❌ Failed:")
@@ -412,11 +424,8 @@ def main():
     # Save results to JSON
     if not args.dry_run:
         results_file = PROJECT_ROOT / "outputs" / "processing_results.json"
-        with open(results_file, 'w') as f:
-            json.dump({
-                'timestamp': datetime.now().isoformat(),
-                'results': results
-            }, f, indent=2)
+        with open(results_file, "w") as f:
+            json.dump({"timestamp": datetime.now().isoformat(), "results": results}, f, indent=2)
         print(f"\nResults saved to: {results_file}")
 
     print(f"\n{'='*80}\n")
@@ -425,5 +434,5 @@ def main():
     sys.exit(0 if len(failed) == 0 else 1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/trnas_in_space.py
+++ b/scripts/trnas_in_space.py
@@ -68,16 +68,16 @@ def should_exclude_trna(trna_id: str) -> bool:
     trna_id_upper = trna_id.upper()
 
     # Exclude selenocysteine - incompatible structure
-    if 'SEC' in trna_id_upper or 'SELENOCYSTEINE' in trna_id_upper:
+    if "SEC" in trna_id_upper or "SELENOCYSTEINE" in trna_id_upper:
         return True
 
     # Exclude mitochondrial tRNAs - different structural architecture
-    if 'MITO-TRNA' in trna_id_upper or trna_id_upper.startswith('MITO-'):
+    if "MITO-TRNA" in trna_id_upper or trna_id_upper.startswith("MITO-"):
         return True
 
     # Exclude initiator methionine tRNAs - different structural features
     # Initiator tRNAs have modified structures for ribosome binding
-    if 'IMET' in trna_id_upper or 'INITIAT' in trna_id_upper or 'FMET' in trna_id_upper:
+    if "IMET" in trna_id_upper or "INITIAT" in trna_id_upper or "FMET" in trna_id_upper:
         return True
 
     # Add other exclusions as needed
@@ -95,21 +95,21 @@ def classify_trna_type(trna_id: str) -> str:
     """
     # First check if this tRNA should be excluded entirely
     if should_exclude_trna(trna_id):
-        return 'exclude'
+        return "exclude"
 
     if trna_id is None:
-        return 'exclude'
+        return "exclude"
 
     trna_id_upper = trna_id.upper()
 
     # Type II: Extended variable arm tRNAs (Leu, Ser, Tyr)
     # These have e1-e24 positions in their extended variable arms
-    if any(amino_acid in trna_id_upper for amino_acid in ['LEU', 'SER', 'TYR']):
-        return 'type2'
+    if any(amino_acid in trna_id_upper for amino_acid in ["LEU", "SER", "TYR"]):
+        return "type2"
 
     # Type I: All other nuclear elongator tRNAs
     # Standard 76nt structure with simple variable arm (positions 47-48)
-    return 'type1'
+    return "type1"
 
 
 def validate_no_global_index_collisions(df: pd.DataFrame):
@@ -122,26 +122,28 @@ def validate_no_global_index_collisions(df: pd.DataFrame):
     # Build preferred labels using the same logic as coordinate generation
     pref_labels = build_pref_label(df)
     df_with_pref = df.copy()
-    df_with_pref['pref_label'] = pref_labels
+    df_with_pref["pref_label"] = pref_labels
 
     # Group by global_index and find any with multiple distinct preferred labels
     collision_groups = []
-    for global_idx, group in df_with_pref.groupby('global_index'):
+    for global_idx, group in df_with_pref.groupby("global_index"):
         if pd.isna(global_idx):
             continue
-        unique_pref_labels = group['pref_label'].unique()
-        unique_pref_labels = [lbl for lbl in unique_pref_labels if pd.notna(lbl) and lbl != '']
+        unique_pref_labels = group["pref_label"].unique()
+        unique_pref_labels = [lbl for lbl in unique_pref_labels if pd.notna(lbl) and lbl != ""]
         if len(unique_pref_labels) > 1:
             # Found collision: multiple preferred labels mapping to same global_index
             collision_groups.append((global_idx, unique_pref_labels, group))
 
     if collision_groups:
         print("\n[ERROR] Global index collisions detected!")
-        print("Multiple structural positions share the same global_index, breaking coordinate alignment:\n")
+        print(
+            "Multiple structural positions share the same global_index, breaking coordinate alignment:\n"
+        )
         for global_idx, labels, group in collision_groups:
             print(f"  global_index {global_idx}:")
             for label in labels:
-                trna_examples = group[group['pref_label'] == label]['trna_id'].unique()[:3]
+                trna_examples = group[group["pref_label"] == label]["trna_id"].unique()[:3]
                 print(f"    - position '{label}' (examples: {', '.join(trna_examples)})")
             print()
 
@@ -152,7 +154,9 @@ def validate_no_global_index_collisions(df: pd.DataFrame):
         print("  3. Expanding reserved coordinate space for extended variable arms")
         sys.exit(1)
 
-    print(f"[ok] Global index validation: No collisions detected among {df['global_index'].nunique()} unique positions")
+    print(
+        f"[ok] Global index validation: No collisions detected among {df['global_index'].nunique()} unique positions"
+    )
 
 
 # --------------------- phase 1: JSON -> rows ----------------------
@@ -339,7 +343,7 @@ def build_pref_label(df: pd.DataFrame) -> pd.Series:
     num_ok_str = num_ok.astype("Int64").astype(str).replace({"<NA>": ""})
 
     # Always preserve Type II extended arm positions (e1, e2, e3, etc.)
-    is_extended_arm = lbl.str.match(r'^e\d+$', na=False)
+    is_extended_arm = lbl.str.match(r"^e\d+$", na=False)
 
     # Use numeric index when valid (1-76), otherwise fall back to label for insertions
     pref = num_ok_str.mask(num_ok_str.eq(""), other=lbl)
@@ -480,7 +484,7 @@ def generate_coordinates_for_type(all_rows, trna_type, output_file, allow_collis
     excluded_count = 0
 
     for row in all_rows:
-        classification = classify_trna_type(row['trna_id'])
+        classification = classify_trna_type(row["trna_id"])
         if classification == trna_type:
             filtered_rows.append(row)
         else:
@@ -490,7 +494,9 @@ def generate_coordinates_for_type(all_rows, trna_type, output_file, allow_collis
         print(f"[error] No {trna_type} tRNAs found in dataset")
         return
 
-    print(f"[info] Processing {len(filtered_rows)} {trna_type} tRNAs (excluded {excluded_count} other types)")
+    print(
+        f"[info] Processing {len(filtered_rows)} {trna_type} tRNAs (excluded {excluded_count} other types)"
+    )
 
     # Convert to DataFrame
     df = pd.DataFrame(filtered_rows).sort_values(["trna_id", "seq_index"]).reset_index(drop=True)
@@ -499,9 +505,9 @@ def generate_coordinates_for_type(all_rows, trna_type, output_file, allow_collis
     pref = build_pref_label(df)
 
     # Use type-specific label ordering
-    if trna_type == 'type1':
+    if trna_type == "type1":
         uniq_labels, to_ord = build_global_label_order_type1(pref)
-    elif trna_type == 'type2':
+    elif trna_type == "type2":
         uniq_labels, to_ord = build_global_label_order_type2(pref)
     else:
         raise ValueError(f"Unknown trna_type: {trna_type}")
@@ -523,7 +529,9 @@ def generate_coordinates_for_type(all_rows, trna_type, output_file, allow_collis
 
     # Validate no collisions (unless allowing them)
     if allow_collisions:
-        print(f"[info] {trna_type.upper()}: Collision validation bypassed due to --allow-collisions flag")
+        print(
+            f"[info] {trna_type.upper()}: Collision validation bypassed due to --allow-collisions flag"
+        )
     else:
         validate_no_global_index_collisions(df)
 
@@ -532,8 +540,16 @@ def generate_coordinates_for_type(all_rows, trna_type, output_file, allow_collis
 
     # Write output
     cols = [
-        "trna_id", "source_file", "seq_index", "sprinzl_index", "sprinzl_label",
-        "residue", "sprinzl_ordinal", "sprinzl_continuous", "global_index", "region",
+        "trna_id",
+        "source_file",
+        "seq_index",
+        "sprinzl_index",
+        "sprinzl_label",
+        "residue",
+        "sprinzl_ordinal",
+        "sprinzl_continuous",
+        "global_index",
+        "region",
     ]
     df.to_csv(output_file, sep="\t", index=False, columns=cols)
 
@@ -553,16 +569,19 @@ def main():
     )
     ap.add_argument("out_tsv", help="Output TSV path (or base name for dual system).")
     ap.add_argument(
-        "--allow-collisions", action="store_true",
-        help="Allow coordinate generation despite isoacceptor-level position collisions."
+        "--allow-collisions",
+        action="store_true",
+        help="Allow coordinate generation despite isoacceptor-level position collisions.",
     )
     ap.add_argument(
-        "--dual-system", action="store_true",
-        help="Generate separate coordinate files for Type I and Type II tRNAs."
+        "--dual-system",
+        action="store_true",
+        help="Generate separate coordinate files for Type I and Type II tRNAs.",
     )
     ap.add_argument(
-        "--type", choices=['type1', 'type2'],
-        help="Generate coordinates for specific tRNA type only (overrides --dual-system)."
+        "--type",
+        choices=["type1", "type2"],
+        help="Generate coordinates for specific tRNA type only (overrides --dual-system).",
     )
     args = ap.parse_args()
 
@@ -591,7 +610,7 @@ def main():
     elif args.dual_system:
         # Generate separate coordinate files for both types
         base_name = args.out_tsv
-        if base_name.endswith('.tsv'):
+        if base_name.endswith(".tsv"):
             base_name = base_name[:-4]
 
         type1_file = f"{base_name}_type1.tsv"
@@ -601,21 +620,25 @@ def main():
         print(f"  Type I (standard): {type1_file}")
         print(f"  Type II (extended): {type2_file}")
 
-        generate_coordinates_for_type(all_rows, 'type1', type1_file, args.allow_collisions)
-        generate_coordinates_for_type(all_rows, 'type2', type2_file, args.allow_collisions)
+        generate_coordinates_for_type(all_rows, "type1", type1_file, args.allow_collisions)
+        generate_coordinates_for_type(all_rows, "type2", type2_file, args.allow_collisions)
 
     else:
         # Legacy unified system (original behavior) - for backwards compatibility
-        print("[warn] Using legacy unified coordinate system. Consider using --dual-system for better results.")
+        print(
+            "[warn] Using legacy unified coordinate system. Consider using --dual-system for better results."
+        )
 
         # Filter out excluded tRNAs for unified system
         filtered_rows = []
         for row in all_rows:
-            classification = classify_trna_type(row['trna_id'])
-            if classification in ['type1', 'type2']:
+            classification = classify_trna_type(row["trna_id"])
+            if classification in ["type1", "type2"]:
                 filtered_rows.append(row)
 
-        df = pd.DataFrame(filtered_rows).sort_values(["trna_id", "seq_index"]).reset_index(drop=True)
+        df = (
+            pd.DataFrame(filtered_rows).sort_values(["trna_id", "seq_index"]).reset_index(drop=True)
+        )
 
         # Use original unified processing (this will likely have collisions)
         pref = build_pref_label(df)
@@ -641,8 +664,16 @@ def main():
         df["region"] = compute_region_column(df)
 
         cols = [
-            "trna_id", "source_file", "seq_index", "sprinzl_index", "sprinzl_label",
-            "residue", "sprinzl_ordinal", "sprinzl_continuous", "global_index", "region",
+            "trna_id",
+            "source_file",
+            "seq_index",
+            "sprinzl_index",
+            "sprinzl_label",
+            "residue",
+            "sprinzl_ordinal",
+            "sprinzl_continuous",
+            "global_index",
+            "region",
         ]
         df.to_csv(args.out_tsv, sep="\t", index=False, columns=cols)
 

--- a/scripts/trnas_in_space.py
+++ b/scripts/trnas_in_space.py
@@ -20,8 +20,9 @@ import os
 import re
 import sys
 from glob import glob
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 
 # ----------------------------- config -----------------------------
 PRECISION = 6  # fixed rounding for sprinzl_continuous before uniquing

--- a/scripts/trnas_in_space.py
+++ b/scripts/trnas_in_space.py
@@ -14,7 +14,11 @@ Usage:
   python trnas_in_space.py /path/to/r2dt_output_dir out.tsv
 """
 
-import os, sys, json, re, argparse
+import argparse
+import json
+import os
+import re
+import sys
 from glob import glob
 import pandas as pd
 import numpy as np
@@ -593,7 +597,7 @@ def main():
         type1_file = f"{base_name}_type1.tsv"
         type2_file = f"{base_name}_type2.tsv"
 
-        print(f"[info] Generating dual coordinate system:")
+        print("[info] Generating dual coordinate system:")
         print(f"  Type I (standard): {type1_file}")
         print(f"  Type II (extended): {type2_file}")
 

--- a/test_trnas_in_space.py
+++ b/test_trnas_in_space.py
@@ -15,7 +15,7 @@ from pathlib import Path
 # Add scripts directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "scripts"))
 
-import trnas_in_space
+import trnas_in_space  # noqa: E402
 
 
 def test_imports():
@@ -152,8 +152,10 @@ def test_should_exclude_trna():
 def test_validate_no_global_index_collisions():
     """Test collision detection function."""
     # Create test DataFrame with no collisions
+    # Must include sprinzl_index column as required by validate_no_global_index_collisions
     good_df = pd.DataFrame({
         'global_index': [1, 2, 3, 4],
+        'sprinzl_index': [1, 2, 3, 4],
         'sprinzl_label': ['1', '2', '3', '4'],
         'trna_id': ['test1', 'test1', 'test1', 'test1']
     })
@@ -167,6 +169,7 @@ def test_validate_no_global_index_collisions():
     # Create test DataFrame with collisions
     bad_df = pd.DataFrame({
         'global_index': [1, 2, 2, 3],  # Collision at index 2
+        'sprinzl_index': [1, 47, -1, 3],  # e1 has invalid sprinzl_index
         'sprinzl_label': ['1', '47', 'e1', '3'],  # Different labels with same index
         'trna_id': ['test1', 'test1', 'test2', 'test1']
     })

--- a/test_trnas_in_space.py
+++ b/test_trnas_in_space.py
@@ -153,12 +153,14 @@ def test_validate_no_global_index_collisions():
     """Test collision detection function."""
     # Create test DataFrame with no collisions
     # Must include sprinzl_index column as required by validate_no_global_index_collisions
-    good_df = pd.DataFrame({
-        'global_index': [1, 2, 3, 4],
-        'sprinzl_index': [1, 2, 3, 4],
-        'sprinzl_label': ['1', '2', '3', '4'],
-        'trna_id': ['test1', 'test1', 'test1', 'test1']
-    })
+    good_df = pd.DataFrame(
+        {
+            "global_index": [1, 2, 3, 4],
+            "sprinzl_index": [1, 2, 3, 4],
+            "sprinzl_label": ["1", "2", "3", "4"],
+            "trna_id": ["test1", "test1", "test1", "test1"],
+        }
+    )
 
     # Should not raise any errors
     try:
@@ -167,15 +169,18 @@ def test_validate_no_global_index_collisions():
         assert False, "Should not exit on good data"
 
     # Create test DataFrame with collisions
-    bad_df = pd.DataFrame({
-        'global_index': [1, 2, 2, 3],  # Collision at index 2
-        'sprinzl_index': [1, 47, -1, 3],  # e1 has invalid sprinzl_index
-        'sprinzl_label': ['1', '47', 'e1', '3'],  # Different labels with same index
-        'trna_id': ['test1', 'test1', 'test2', 'test1']
-    })
+    bad_df = pd.DataFrame(
+        {
+            "global_index": [1, 2, 2, 3],  # Collision at index 2
+            "sprinzl_index": [1, 47, -1, 3],  # e1 has invalid sprinzl_index
+            "sprinzl_label": ["1", "47", "e1", "3"],  # Different labels with same index
+            "trna_id": ["test1", "test1", "test2", "test1"],
+        }
+    )
 
     # Should exit with error
     import pytest
+
     with pytest.raises(SystemExit):
         trnas_in_space.validate_no_global_index_collisions(bad_df)
 

--- a/test_trnas_in_space.py
+++ b/test_trnas_in_space.py
@@ -6,11 +6,12 @@ Run with: python -m pytest test_trnas_in_space.py -v
 Or: python test_trnas_in_space.py
 """
 
-import sys
 import os
-import pandas as pd
-import numpy as np
+import sys
 from pathlib import Path
+
+import numpy as np
+import pandas as pd
 
 # Add scripts directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "scripts"))


### PR DESCRIPTION
- Fix failing test_validate_no_global_index_collisions test by adding
  required sprinzl_index column to test DataFrames
- Convert 19 f-strings without placeholders to regular strings
- Remove unused imports (format_alignment, re, Tuple, sys)
- Remove unused variables (manual, result)
- Fix E128/E127 continuation line indentation issues
- Fix type annotation issues (Path vs str reassignment)
- Add types-PyYAML to requirements.txt for mypy
- Split multiple imports per line (E401)
- Add noqa comments for intentional E402 violations
- Add blank lines for E302/E305 compliance

All 10 tests now pass. Only C901 complexity warnings remain
(acceptable, would require significant refactoring to resolve).